### PR TITLE
Add permissons to download artifacts

### DIFF
--- a/docs/config/github-token.md
+++ b/docs/config/github-token.md
@@ -29,6 +29,7 @@ id-token | write | For [aws-actions/configure-aws-credentials](https://github.co
 contents | read | Checkout
 issues | read | `gh pr list`'s `-l` option requires the read permission
 pull-requests | write | pull request labels
+actions | read | Download artifacts 
 
 ### Required permissions of GitHub App
 
@@ -36,6 +37,7 @@ name | permission | description
 --- | --- | ---
 Contents | write | create commits and branches
 Pull Requests | write | open pull requests
+Actions | read | download artifacts
 
 ### Create GitHub App
 


### PR DESCRIPTION
After updating tfaction to 0.7, terraform-apply action is failing.
As shown below, the error was that the workflow permission was missing, so I added the `actions` permission and it now succeeds.

> couldn't fetch workflows for ***/***: HTTP 403: Resource not accessible by integration (https://api.github.com/repos/***/***/actions/workflows?per_page=100&page=1)

Perhaps the `actions` permission was needed for [this part](https://github.com/suzuki-shunsuke/tfaction/blob/34103fcfee451b610e06c1c78391082c2f8d7a88/terraform-apply/download_plan_file.sh#L25) of the artifacts download process.