### PR TITLE
added `issue:write` to required permission of GitHub App

### DIFF
--- a/docs/config/github-token.md
+++ b/docs/config/github-token.md
@@ -38,6 +38,7 @@ name | permission | description
 Contents | write | create commits and branches
 Pull Requests | write | open pull requests
 Actions | read | download artifacts
+Issue | write | create labels
 
 ### Create GitHub App
 


### PR DESCRIPTION
Hi @suzuki-shunsuke,
I added permission of Issue(write) to GitHub App's section.

If doesn’t have `issue:write` permission, the following error occured on Generate token step when using [tfaction-example](https://github.com/suzuki-shunsuke/tfaction-example)'s workflow.
![CleanShot 2024-03-17 at 01 09 40](https://github.com/suzuki-shunsuke/tfaction-docs/assets/29038315/e78f196d-8972-466f-9ee4-d35921795468)
